### PR TITLE
Task.7-3 記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController # base_api_contorller を継承
+    def index
+      articles = Article.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 module Api::V1
-  class ArticlesController < BaseApiController # base_api_contorller を継承
+  class ArticlesController < BaseApiController
+    # base_api_contorller を継承
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { Faker::Books::CultureSeries }
-    body { "MyText" }
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
     user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -24,6 +24,27 @@ RSpec.describe Article, type: :model do
       expect(article).not_to be_valid
     end
   end
+end
+
+  RSpec.describe "Api::V1::Articles", type: :request do
+    describe "GET /articles" do
+      subject { get(api_v1_articles_path) }
+
+      let!(:article1) { create(:article, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article) }
+
+      it "記事の一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user" ]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email" ]
+      end
+    end
+  end
 
   # pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -26,25 +26,23 @@ RSpec.describe Article, type: :model do
   end
 end
 
-  RSpec.describe "Api::V1::Articles", type: :request do
-    describe "GET /articles" do
-      subject { get(api_v1_articles_path) }
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
 
-      let!(:article1) { create(:article, updated_at: 1.days.ago) }
-      let!(:article2) { create(:article, updated_at: 2.days.ago) }
-      let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
 
-      it "記事の一覧が取得できる" do
-        subject
-        res = JSON.parse(response.body)
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
 
-        expect(response).to have_http_status(:ok)
-        expect(res.length).to eq 3
-        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-        expect(res[0].keys).to eq ["id", "title", "updated_at", "user" ]
-        expect(res[0]["user"].keys).to eq ["id", "name", "email" ]
-      end
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
-
-  # pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- 記事のAPI実装に関するFactoryの修正
- 記事一覧のAPIの実装に必要なserializer を追加
- 記事一覧を返すAPI及びテストを実装