### PR TITLE
Task. 7-5 記事作成の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -10,5 +10,16 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+    def article_params
+      params.require(:article). permit(:title, :body)
+    end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  # current_user のダミーコード
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params)}
+
+    let(:params) { {article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+
+    # stub
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事のレコードが作成できる" do
+      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
##概要
- base_api_contrillerにダミーのcurrent_userメソッドを実装
- 記事の新規作成に関するAPI、テストを実装